### PR TITLE
Correct method invoked to set widget background color

### DIFF
--- a/lib/cdk/cdk_objs.rb
+++ b/lib/cdk/cdk_objs.rb
@@ -176,7 +176,7 @@ module CDK
       holder = CDK.char2Chtype(color, junk1, junk2)
 
       # Set the widget's background color
-      self.SetBackAttrObj(holder[0])
+      self.setBKattr(holder[0])
     end
 
     # Set the widget's title.


### PR DESCRIPTION
Noticed that invoking 'setBackgroundColor' on any widget results against the current library results in an error. Take the following example:

```
require 'ncurses'
require 'cdk'

win = Ncurses.initscr
CDK::Draw.initCDKColor
scr = CDK::SCREEN.new(win)

widget = CDK::SLIDER.new(scr, 5, 5, "Foo", "Bar",
                         ' '.ord, 30, 1, 1, 10, 1, 2, false, false)

widget.setBackgroundColor("</29>")
widget.activate([])
```

With the attached patch, this succeeds in setting the widget color